### PR TITLE
Differentiate between number of reflectors and parrot

### DIFF
--- a/P25Gateway/Reflectors.cpp
+++ b/P25Gateway/Reflectors.cpp
@@ -88,6 +88,12 @@ bool CReflectors::load()
 		::fclose(fp);
 	}
 
+	size_t size = m_reflectors.size();
+	if (size == 0U)
+		return false;
+
+	LogInfo("Loaded %u P25 reflectors", size);
+
 	// Add the Parrot entry
 	if (m_parrotPort > 0U) {
 		CP25Reflector* refl = new CP25Reflector;
@@ -95,13 +101,8 @@ bool CReflectors::load()
 		refl->m_address = CUDPSocket::lookup(m_parrotAddress);
 		refl->m_port    = m_parrotPort;
 		m_reflectors.push_back(refl);
+		LogInfo("Loaded P25 parrot");
 	}
-
-	size_t size = m_reflectors.size();
-	if (size == 0U)
-		return false;
-
-	LogInfo("Loaded %u P25 reflectors", size);
 
 	return true;
 }


### PR DESCRIPTION
Per default ParrotAddress and ParrotPort are set. That make P25Gateway count it as extra reflector which is a little confusing because the log says it loaded X reflectors but P25Hosts contains only X-1 reflectors (The parrot always counts as 1 extra reflector).
This PR outputs only the real number of reflectors and logs an extra line if the parrot is enabled.