### PR TITLE
Fix thread lib

### DIFF
--- a/P25Parrot/Makefile
+++ b/P25Parrot/Makefile
@@ -1,7 +1,7 @@
 CC      = gcc
 CXX     = g++
 CFLAGS  = -g -O3 -Wall -std=c++0x
-LIBS    =
+LIBS    = -lpthread
 LDFLAGS = -g
 
 OBJECTS = Log.o Network.o P25Parrot.o Parrot.o StopWatch.o Thread.o Timer.o UDPSocket.o Utils.o


### PR DESCRIPTION
Fixes the rror mentioned in the Yahoo Group by Ian VK2HK:

g++ Log.o Network.o P25Parrot.o Parrot.o StopWatch.o Thread.o Timer.o                                                                
UDPSocket.o Utils.o -g -O3 -Wall -std=c++0x  -o P25Parrot                                                                            
Makefile:12: recipe for target 'P25Parrot’ failed