### PR TITLE
Make IPV4 as a fallback, avoids open() failure (errno EAFNOSUPPORT, RPi).

### DIFF
--- a/P25Gateway/P25Network.cpp
+++ b/P25Gateway/P25Network.cpp
@@ -43,11 +43,11 @@ bool CP25Network::open()
 {
 	LogInfo("Opening P25 network connection");
 
-	bool ret = m_socket.open(0, PF_INET, "", m_port);
-	if (!ret)
-		return false;
+	bool ret = m_socket.open(0, PF_INET6, "", m_port);
+	if (ret)
+		return true;
 
-	return m_socket.open(1, PF_INET6, "", m_port);
+	return m_socket.open(1, PF_INET, "", m_port);
 }
 
 bool CP25Network::write(const unsigned char* data, unsigned int length, const sockaddr_storage& addr, unsigned int addrLen)


### PR DESCRIPTION
Since the last change, it fails to create the IPV6 socket for P25Network.
Same problem with NXDNGateway (PR raised).