### PR TITLE
display correct IP address

### DIFF
--- a/P25Reflector/UDPSocket.cpp
+++ b/P25Reflector/UDPSocket.cpp
@@ -169,14 +169,14 @@ char* CUDPSocket::display(const sockaddr_storage& addr, char* buffer, unsigned i
 	switch (addr.ss_family) {
 	case AF_INET: {
 		struct sockaddr_in* in4 = (struct sockaddr_in*)&addr;
-		::inet_ntop(AF_INET, &in4, buffer, length);
+		::inet_ntop(AF_INET, &in4->sin_addr, buffer, length);
 		::sprintf(buffer + ::strlen(buffer), ":%u", in4->sin_port);
 	}
 		break;
 
 	case AF_INET6: {
 		struct sockaddr_in6* in6 = (struct sockaddr_in6*)&addr;
-		::inet_ntop(AF_INET6, &in6, buffer, length);
+		::inet_ntop(AF_INET6, &in6->sin6_addr, buffer, length);
 		::sprintf(buffer + ::strlen(buffer), ":%u", in6->sin6_port);
 	}
 		break;


### PR DESCRIPTION
Fixed typo were the sin_addr and sin6_addr attributes were not being used to obtain ip address in the display method