### PR TITLE
Avoid memory corruption - Delete correct expired or unlinking repeater 

### DIFF
--- a/P25Reflector/P25Reflector.cpp
+++ b/P25Reflector/P25Reflector.cpp
@@ -233,8 +233,8 @@ void CP25Reflector::run()
 
 				for (std::vector<CP25Repeater*>::iterator it = m_repeaters.begin(); it != m_repeaters.end(); ++it) {
 					if (CUDPSocket::match((*it)->m_addr, rpt->m_addr)) {
-						m_repeaters.erase(it);
 						delete *it;
+						m_repeaters.erase(it);
 						break;
 					}
 				}
@@ -304,8 +304,8 @@ void CP25Reflector::run()
 				LogMessage("Removing %s (%s) disappeared", (*it)->m_callsign.c_str(),
 														   CUDPSocket::display((*it)->m_addr, buff, 80U));
 
-				m_repeaters.erase(it);
 				delete *it;
+				m_repeaters.erase(it);
 				break;
 			}
 		}


### PR DESCRIPTION
iterator is changed by erase vector function thus we were deleting incorrect rpt from memory and leaving memory unstable... 
The symptom of this problem was extra repeaters added when others expire and bad audio being received by those stations with the extra repeaters...