### PR TITLE
Update P25Hosts.txt

### DIFF
--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -666,5 +666,5 @@
 # 72405 P25 MGBRASIL
 72405 mgbrasil.duckdns.org 41000
 
-# 72406 KM4HJJ repeater Pompano, Florida
-72406 km4hjj-p25.dyndns-server.com
+# 65101 KM4HJJ repeater Pompano, Florida
+65101 km4hjj-p25.dyndns-server.com

--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -663,8 +663,10 @@
 # 65100 P25 2007DXgroup
 65100	89.46.75.115	41000
 
+# 65101 KM4HJJ repeater Pompano, Florida
+65101 km4hjj-p25.dyndns-server.com 41000
+
 # 72405 P25 MGBRASIL
 72405 mgbrasil.duckdns.org 41000
 
-# 65101 KM4HJJ repeater Pompano, Florida
-65101 km4hjj-p25.dyndns-server.com
+


### PR DESCRIPTION
Motorola P25 system (XTS2500 specifically) configuration limits TG to 65535 groups. Requesting TG to be reassigned to 65101 (or numerically lower) to permit TG to be programmed into Motorola P25 equipment.