### PR TITLE
Update P25Hosts.txt

### DIFF
--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -144,7 +144,7 @@
 # 946 FlagTorchSociety
 946	xlx.flagandtorchsociety.com	41000
 
-# 947 W8LRK Livingston County Amateur Radio Klub (Bridged to XLX947B)
+# 947 W8LRK Livingston Amateur Radio Klub (Bridged to XLX947B)
 947 w8lrkp25.dyndns.org	41001
 
 # 994 The Online Radio Club (Bridged to XLX994)
@@ -638,9 +638,6 @@
 
 # 31264 XLX625 The BROniverse www.wa8bro.com
 31264	p25.dudetronics.com	41000
-
-# 31267 W8LRK Blue Zone - Livingston County Amateur Radio Klub
-31267	w8lrkp25.dyndns.org	41001
 
 # 31291 Southwest Missouri (P25/DMR)
 31291	p25.ddns.me	41001


### PR DESCRIPTION
Line# 147 updated to remove the word county to shorten the description.  Line# 642/643 were deleted as this talkgroup 31267 is depreciated and no longer operational.  This is a resubmission of these due to an error in removing the talkgroup details from the description; however, looking through the file, there are many like this and it's really an unnecessary duplication of this information when it's viewed on Pi-Star's website and other resources.