### PR TITLE
Clean up currentTG fields completely when hangtimer expires

### DIFF
--- a/P25Gateway/P25Gateway.cpp
+++ b/P25Gateway/P25Gateway.cpp
@@ -629,12 +629,13 @@ int CP25Gateway::run()
 				if (voice != NULL)
 					voice->unlinked();
 
-				currentAddrLen = 0U;
-
-				hangTimer.stop();
 			}
 
-			currentTG = 0U;
+			currentTG        = 0U;
+			currentAddrLen   = 0U;
+			currentIsStatic  = false;
+
+			hangTimer.stop();
 		}
 
 		localNetwork.clock(ms);


### PR DESCRIPTION
This patch forces the hangtime expiration code to update all fields associated with the current talk group.  Several places in the code use currentAddrLen>0 as a test that we are in a talk group.  This forces more consistency and seems like good coding hygiene.  

This in part an attempt to eliminate the TG=0 information coming into the WPSD dashboard from the network.