### PR TITLE
Update P25Hosts.txt

### DIFF
--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -46,7 +46,7 @@
 235	p25.dvsph.net	41000
 
 # 260 HBLink Poland P25
-260	p25.hblink.pl	41000
+260	80.211.195.50	41005
 
 # 276 Amateur Radio Network
 276 p25.kc8cpw.com 41000


### PR DESCRIPTION
Hi Jonathan.

I have a question, is it possible to change the server IP address? A colleague once used this server, but now he gave up and his address has expired, it would be good that the TG260 number could still be used. The server is running, we only have no entry in the global P25 list. You could change this old entry to the new IP 80.211.195.50 and port 41005. The name can be the same.

Vy 73
Gregory SP5NAF