### PR TITLE
Flush voice to avoid buzz problems with competing audio streams with voice.

### DIFF
--- a/P25Gateway/P25Gateway.cpp
+++ b/P25Gateway/P25Gateway.cpp
@@ -526,8 +526,10 @@ int CP25Gateway::run()
 
 		if (voice != NULL) {
 			unsigned int length = voice->read(buffer);
-			if (length > 0U)
+			while (length > 0U) {
 				localNetwork.write(buffer, length);
+				length = voice->read(buffer);
+			}
 		}
 
 		if (remoteSocket != NULL) {

--- a/P25Gateway/P25Gateway.cpp
+++ b/P25Gateway/P25Gateway.cpp
@@ -430,15 +430,10 @@ int CP25Gateway::run()
 				dstTG  = (buffer[1U] << 16) & 0xFF0000U;
 				dstTG |= (buffer[2U] << 8)  & 0x00FF00U;
 				dstTG |= (buffer[3U] << 0)  & 0x0000FFU;
-			} else if (buffer[0U] == 0x66U) {
-				srcId  = (buffer[1U] << 16) & 0xFF0000U;
-				srcId |= (buffer[2U] << 8)  & 0x00FF00U;
-				srcId |= (buffer[3U] << 0)  & 0x0000FFU;
-
 				if (dstTG != currentTG) {
 					if (currentAddrLen > 0U) {
 						std::string callsign = lookup->find(srcId);
-						LogMessage("Unlinking from reflector %u by %s", currentTG, callsign.c_str());
+						LogMessage("Unlinking from reflector %u", currentTG);
 
 						if (!currentIsStatic) {
 							remoteNetwork.unlink(currentAddr, currentAddrLen);
@@ -479,7 +474,7 @@ int CP25Gateway::run()
 					// Link to the new reflector
 					if (currentAddrLen > 0U) {
 						std::string callsign = lookup->find(srcId);
-						LogMessage("Switched to reflector %u due to RF activity from %s", currentTG, callsign.c_str());
+						LogMessage("Switched to reflector %u due to RF activity", currentTG);
 
 						if (!currentIsStatic) {
 							remoteNetwork.poll(currentAddr, currentAddrLen);
@@ -500,6 +495,12 @@ int CP25Gateway::run()
 							voice->linkedTo(dstTG);
 					}
 				}
+
+			} else if (buffer[0U] == 0x66U) {
+				srcId  = (buffer[1U] << 16) & 0xFF0000U;
+				srcId |= (buffer[2U] << 8)  & 0x00FF00U;
+				srcId |= (buffer[3U] << 0)  & 0x0000FFU;
+
 			}
 
 			if (buffer[0U] == 0x80U) {

--- a/P25Gateway/Voice.cpp
+++ b/P25Gateway/Voice.cpp
@@ -121,8 +121,8 @@ m_positions()
 	m_imbeFile = directory + "/" + language + ".imbe";
 #endif
 
-	// Approximately 10 seconds worth
-	m_voiceData = new unsigned char[10U * 50U * IMBE_LENGTH];
+	// Approximately 100 seconds worth
+	m_voiceData = new unsigned char[100U * 50U * IMBE_LENGTH];
 }
 
 CVoice::~CVoice()
@@ -237,7 +237,7 @@ void CVoice::createVoice(unsigned int tg, const std::vector<std::string>& words)
 	m_voiceLength += SILENCE_LENGTH * IMBE_LENGTH;
 
 	// Round to the next highest LDU frame length
-	unsigned int n = (m_voiceLength / IMBE_LENGTH) % LDU_LENGTH;
+	unsigned int n =(m_voiceLength / IMBE_LENGTH) % LDU_LENGTH;
 	if (n > 0U)
 		m_voiceLength += (LDU_LENGTH - n) * IMBE_LENGTH;
 
@@ -253,6 +253,9 @@ void CVoice::createVoice(unsigned int tg, const std::vector<std::string>& words)
 			CPositions* position = m_positions.at(*it);
 			unsigned int start  = position->m_start;
 			unsigned int length = position->m_length;
+			//check that we are not overrunning the buffer.
+			if (length+start> 100U * 50U * IMBE_LENGTH)
+				break;
 			::memcpy(m_voiceData + pos, m_imbe + start, length);
 			pos += length;
 		}
@@ -276,130 +279,128 @@ unsigned int CVoice::read(unsigned char* data)
 		return 17U;
 	}
 
-	unsigned int count = m_stopWatch.elapsed() / P25_FRAME_TIME;
 
 	unsigned int length = 0U;
 
-	if (m_sent < count) {
-		switch (m_n) {
-		case 0x62U:
-			::memcpy(data, REC62, 22U);
-			::memcpy(data + 10U, m_voiceData + offset, IMBE_LENGTH);
-			length = 22U;
-			m_n = 0x63U;
-			break;
-		case 0x63U:
-			::memcpy(data, REC63, 14U);
-			::memcpy(data + 1U, m_voiceData + offset, IMBE_LENGTH);
-			length = 14U;
-			m_n = 0x64U;
-			break;
-		case 0x64U:
-			::memcpy(data, REC64, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x65U;
-			break;
-		case 0x65U:
-			::memcpy(data, REC65, 17U);
-			data[1U] = (m_dstId >> 16) & 0xFFU;
-			data[2U] = (m_dstId >> 8) & 0xFFU;
-			data[3U] = (m_dstId >> 0) & 0xFFU;
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x66U;
-			break;
-		case 0x66U:
-			::memcpy(data, REC66, 17U);
-			data[1U] = (m_srcId >> 16) & 0xFFU;
-			data[2U] = (m_srcId >> 8) & 0xFFU;
-			data[3U] = (m_srcId >> 0) & 0xFFU;
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x67U;
-			break;
-		case 0x67U:
-			::memcpy(data, REC67, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x68U;
-			break;
-		case 0x68U:
-			::memcpy(data, REC68, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x69U;
-			break;
-		case 0x69U:
-			::memcpy(data, REC69, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x6AU;
-			break;
-		case 0x6AU:
-			::memcpy(data, REC6A, 16U);
-			::memcpy(data + 4U, m_voiceData + offset, IMBE_LENGTH);
-			length = 16U;
-			m_n = 0x6BU;
-			break;
-		case 0x6BU:
-			::memcpy(data, REC6B, 22U);
-			::memcpy(data + 10U, m_voiceData + offset, IMBE_LENGTH);
-			length = 22U;
-			m_n = 0x6CU;
-			break;
-		case 0x6CU:
-			::memcpy(data, REC6C, 14U);
-			::memcpy(data + 1U, m_voiceData + offset, IMBE_LENGTH);
-			length = 14U;
-			m_n = 0x6DU;
-			break;
-		case 0x6DU:
-			::memcpy(data, REC6D, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x6EU;
-			break;
-		case 0x6EU:
-			::memcpy(data, REC6E, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x6FU;
-			break;
-		case 0x6FU:
-			::memcpy(data, REC6F, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x70U;
-			break;
-		case 0x70U:
-			::memcpy(data, REC70, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x71U;
-			break;
-		case 0x71U:
-			::memcpy(data, REC71, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x72U;
-			break;
-		case 0x72U:
-			::memcpy(data, REC72, 17U);
-			::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
-			length = 17U;
-			m_n = 0x73U;
-			break;
-		default:
-			::memcpy(data, REC73, 16U);
-			::memcpy(data + 4U, m_voiceData + offset, IMBE_LENGTH);
-			length = 16U;
-			m_n = 0x62U;
-			break;
-		}
 
-		m_sent++;
+	switch (m_n) {
+	case 0x62U:
+		::memcpy(data, REC62, 22U);
+		::memcpy(data + 10U, m_voiceData + offset, IMBE_LENGTH);
+		length = 22U;
+		m_n = 0x63U;
+		break;
+	case 0x63U:
+		::memcpy(data, REC63, 14U);
+		::memcpy(data + 1U, m_voiceData + offset, IMBE_LENGTH);
+		length = 14U;
+		m_n = 0x64U;
+		break;
+	case 0x64U:
+		::memcpy(data, REC64, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x65U;
+		break;
+	case 0x65U:
+		::memcpy(data, REC65, 17U);
+		data[1U] = (m_dstId >> 16) & 0xFFU;
+		data[2U] = (m_dstId >> 8) & 0xFFU;
+		data[3U] = (m_dstId >> 0) & 0xFFU;
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x66U;
+		break;
+	case 0x66U:
+		::memcpy(data, REC66, 17U);
+		data[1U] = (m_srcId >> 16) & 0xFFU;
+		data[2U] = (m_srcId >> 8) & 0xFFU;
+		data[3U] = (m_srcId >> 0) & 0xFFU;
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x67U;
+		break;
+	case 0x67U:
+		::memcpy(data, REC67, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x68U;
+		break;
+	case 0x68U:
+		::memcpy(data, REC68, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x69U;
+		break;
+	case 0x69U:
+		::memcpy(data, REC69, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x6AU;
+		break;
+	case 0x6AU:
+		::memcpy(data, REC6A, 16U);
+		::memcpy(data + 4U, m_voiceData + offset, IMBE_LENGTH);
+		length = 16U;
+		m_n = 0x6BU;
+		break;
+	case 0x6BU:
+		::memcpy(data, REC6B, 22U);
+		::memcpy(data + 10U, m_voiceData + offset, IMBE_LENGTH);
+		length = 22U;
+		m_n = 0x6CU;
+		break;
+	case 0x6CU:
+		::memcpy(data, REC6C, 14U);
+		::memcpy(data + 1U, m_voiceData + offset, IMBE_LENGTH);
+		length = 14U;
+		m_n = 0x6DU;
+		break;
+	case 0x6DU:
+		::memcpy(data, REC6D, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x6EU;
+		break;
+	case 0x6EU:
+		::memcpy(data, REC6E, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x6FU;
+		break;
+	case 0x6FU:
+		::memcpy(data, REC6F, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x70U;
+		break;
+	case 0x70U:
+		::memcpy(data, REC70, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x71U;
+		break;
+	case 0x71U:
+		::memcpy(data, REC71, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x72U;
+		break;
+	case 0x72U:
+		::memcpy(data, REC72, 17U);
+		::memcpy(data + 5U, m_voiceData + offset, IMBE_LENGTH);
+		length = 17U;
+		m_n = 0x73U;
+		break;
+	default:
+		::memcpy(data, REC73, 16U);
+		::memcpy(data + 4U, m_voiceData + offset, IMBE_LENGTH);
+		length = 16U;
+		m_n = 0x62U;
+		break;
 	}
+
+	m_sent++;
 
 	return length;
 }


### PR DESCRIPTION
This patch fixes an issue with the voice and traffic competing for the transmitter.  Instead it flushes the voice traffic as soon as possible.  

This problem is described at https://forum.pistar.uk/viewtopic.php?t=2072 

This is a 90% solution as the implementation cuts off a the tail end of the voice. That means typically 2 or 3 digits.  

Further research is needed to make it compliant with TIA-102-BAAA-A 8.2.3

I recommend pulling this as it gets rid of that buzz and the parrot is probably one of the first places someone will connect so it makes for a much more polished introduction.