### PR TITLE
Throttle packets to MMDVM to not overflow ringbuffer.

### DIFF
--- a/P25Gateway/P25Gateway.cpp
+++ b/P25Gateway/P25Gateway.cpp
@@ -348,6 +348,7 @@ int CP25Gateway::run()
 					localNetwork.write(buffer, len);
 
 					hangTimer.start();
+					CThread::sleep(18U); //throttle to prevent buffer overflow in MMDVM
 				}
 			} else if (currentTG == 0U) {
 				bool poll = false;
@@ -529,6 +530,7 @@ int CP25Gateway::run()
 			unsigned int length = voice->read(buffer);
 			while (length > 0U) {
 				localNetwork.write(buffer, length);
+				CThread::sleep(18U); //throttle to prevent buffer overflow in MMDVM
 				length = voice->read(buffer);
 			}
 		}


### PR DESCRIPTION
Allowing Voice data to flow freely to MMDVM caused a buffer to offerflow.  This was especially obvious when using the parrot.  The voice and backed up UDP packets could flow significantly faster than realtime.  This would occur after about approximately 2 seconds.  A sleep of 18 milliseconds protects this buffer and should extend it out to allow approximately 20 seconds before the buffer overflows.  