### PR TITLE
Cleanup P25Hosts.txt

### DIFF
--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -49,16 +49,16 @@
 260	80.211.195.50	41005
 
 # 276 Amateur Radio Network
-276 p25.kc8cpw.com 41000
+276 p25.kc8cpw.com	41000
 
 # 304 W8ARA P25
 304	ara.selfip.net	41000
 
 # 312 TriState (IL, IN, WI) P25
-312 p25.tristatedmr.org 41000
+312 p25.tristatedmr.org	41000
 
 # 334 Mexico P25 (by XE1F)
-334	reflector.p25.link		41008
+334	reflector.p25.link	41008
 
 # 357 VARG http://www.varg.club
 357	3.215.215.169	41010
@@ -73,19 +73,16 @@
 445	p25.Supermag.fishersaudio.com.au	41000
 
 # 456 Apco25 Ruhrgebiet/NRW Germany
-456 456.ham-p25.de 41000
+456	456.ham-p25.de	41000
 
 # 478 Ham Radio Village URF478
 478 urf.hamvillage.org 41000
 
-# 530 NZ
-530	zldigitalreflectors.hopto.org	41000
-
 # 554 Georgia 900 P25 555 backup
-554 georgia900p25.us 41003
+554	georgia900p25.us	41003
 
 # 555 Georgia 900 P25
-555 georgia900p25.us 41000
+555	georgia900p25.us	41000
 
 # 556 ARFCOM AR15.com
 556	reflector.site	41000
@@ -94,7 +91,7 @@
 621	urf.hrcc.link	41000
 
 # 665 KK6RQ TAC-2
-665 area52.zapto.org 41001
+665	area52.zapto.org	41001
 
 # 666 Brazil PY1IP P25 Reflector - http://tg666.p25.py1ip.com
 666	p25.py1ip.com	41000
@@ -109,22 +106,19 @@
 730	sdradio.cl	41000
 
 # 732 Octane Network P25 to XLX732
-732 p25.octanenetwork.net 41000
+732	p25.octanenetwork.net	41000
 
 # 739 Broadnet Repeater System, NYC
-739  P25.ke2aem.com  41000
+739	P25.ke2aem.com	41000
 
 # 747 DVMproject2P25 - KN6TYF
-747  fne.dv.kn6tyf.com  41001
+747	fne.dv.kn6tyf.com	41001
 
 # 762 W4PFT Multimode Linked to BM TG 312486-Franklin County, GA
 762	p25.w4pft.com	41000
 
 # 777 Almost Heaven WV P25
-777 wv777p25.ddns.net 41005
-
-# 822 TH-ASL-5508
-822	p25.xlx822.com	41000
+777	wv777p25.ddns.net	41005
 
 # 841 Team Wave
 841	mx0wvv.ddns.net	41000
@@ -135,32 +129,26 @@
 # 848 Chandler Hams
 848	xlx848.kk7mnz.com	41000
 
-# 858 San Diego, CA
-858	nz6d.dx40.com	41000
-
 # 865 K1LNX Multimode Server - Knoxville, TN
 865	knoxp25.k1lnx.net	41000
 
 # 888 KN6TYF Lucky Radio MM DV
-888  reflector1.dv.jchang.io  41000
+888	reflector1.dv.jchang.io	41000
 
 # 891 Western New York Digital Multimode Network - http://wny-digital.network - Buffalo, NY
 891	p25.wny-digital.network	41000
 
 # 900 New England 900 MHz P25 Network
-900 stn4571.ip.irlp.net 41000
+900	stn4571.ip.irlp.net	41000
 
 # 909 Volunteer Radio Association, Thailand P25 Network
-909 xlx.vra.or.th 41000
+909	xlx.vra.or.th	41000
 
 # 910 Washington,DC - Virginia - Maryland
 910	p25.freeddns.org	41000
 
 # 925 MotoChat 
 925	p25.motochat.eu	41009
-
-# 926 HamFurs/LoFAR MultiMode Bridge
-926	urf.kf3rry.org	41000
 
 # 927 Southern California
 927	927.org	41000
@@ -171,9 +159,6 @@
 # 947 W8LRK Livingston Amateur Radio Klub (Bridged to XLX947B)
 947 w8lrkp25.dyndns.org	41001
 
-# 994 The Online Radio Club (Bridged to XLX994)
-994	misc.openreflector.com	41000
-
 # 1007 The Harley-Hangout "TGIF TG-1007 Multi-Function Bridge"
 1007	43773.kb5rir.com	41003
 
@@ -183,44 +168,35 @@
 # 1453 Turkish Dijital Radio Network
 1453	2861.adn.systems	41000
 
-# 1701 Sector 001
-1701	hamsomniac.mooo.com	41001
-
 # 1928 Motorola Nerd Network
 1928	216.128.134.7	41000
 
 # 2043 Dutch P25 Urfd Reflector URFNL1
-2043    141.95.54.250    41000
+2043	141.95.54.250	41000
 
 # 2044 P25 The Netherlands Main Reflector
-2044    51.83.46.75    41000
+2044	51.83.46.75	41000
 
 # 2050 Florida Simulticast Group
 2050	reflector.p25.link	41009
 
 # 2113 Keywork Reflector
-2113  souche.asuscomm.com  41000
+2113	souche.asuscomm.com	41000
 
 # 2121 Cambria Multi-Mode Hub
-2121  108.174.58.66 41000
+2121	108.174.58.66	41000
 
 # 2140 P25 Reflector BM DMR+ Multi 
 2140	andalucia.xreflector.es	41002
 
 # 2147 P25 Reflector ANDALUCIA 
-2147	andalucia.xreflector.es 41001
+2147	andalucia.xreflector.es	41001
 
 # 2221 IT PIEDMONT GDO
 2221	iz1zpj.duckdns.org	41000
 
 # 2231 IT Sardinia Is. - Multimode - https://is0.org
 2231	p25.is0.org	41000
-
-# 2263 Bucharest YO3 P25 Network
-2263	p25.dstar-yo.ro	41003
-
-# 2265 Baia Mare YO5 P25 Network
-2265	p25.dstar-yo.ro	41005
 
 # 2284 Basel Switzerland - https://p25.network
 2284	p25.network	41000
@@ -231,14 +207,8 @@
 # 2350 UK ChatterBOX
 2350	p252350.freestar.network	41001
 
-# RU DMR TG2503
-2503	p25.r1ik.ru	41000
-
 # 2700 Old Melbourne Florida Repeater Association
 2700	2700p25.ddns.net	41000
-
-# 3023 Ontario Crosslink
-3023	ontxlink.hopto.org	41000
 
 # 3026 Alberta
 3026	reflector.p25alberta.ca	41000
@@ -247,13 +217,10 @@
 3120	lkdvm.xreflector.es	41000
 
 # 3122 Louisiana Statewide
-3122	statewide.swlalink.com		41000
+3122	statewide.swlalink.com	41000
 
 # 3142 Pennsylvania
 3142	3.215.215.169	41002
-
-# 3147 Tennessee
-3147	p25tn.w4kdg.org	41000
 
 # 3149 Utah
 3149	p25.aarthek.net	41000
@@ -277,16 +244,16 @@
 4519	N0oba1.asuscomm.com	41005
 
 # 4584 Great Lakes Digital Common (P25/DMR/NXDN/YSF/DSTAR/M17)
-4584 gldcom.dyndns.org 41000
+4584	gldcom.dyndns.org	41000
 
 # 5000 ALL THE COMMS
 5000	p25.p25stuff.com	41000
 
 # 5030 KK7GKG P25 to ASL Gateway
-5030  site1a.redmtncomms.com  41000
+5030	site1a.redmtncomms.com	41000
 
 # 5031 KK7GKG DEVELOPMENT
-5031  site0.redmtncomms.com
+5031	site0.redmtncomms.com
 
 # 5057 VK7 TAS (hosted by VK7HSE)
 5057	45.248.50.37	41000
@@ -295,7 +262,7 @@
 5205	5205.p25dvm.com	41000
 
 # 5500 IVC Wireless Technology Club
-5500 p25.ivc.radio 41000
+5500	p25.ivc.radio	41000
 
 # 5658 DuckFar Repeater Group, Chicago
 5658	duckfarw9bmk.gotdns.com	41000
@@ -309,17 +276,14 @@
 # 7144 Chiriqui Link Panama
 7144	p25-hp3.dnsup.net	41000
 
-# 7160 Peru Digital
-7160	p25.dmr-peru.pe	41000
-
 # 7225 MULTIPROTOCOLO ARGENTINA
 7225	ysfarg.ddns.net	41000
 
 # 7240 MASTER-SUL Brasil
-7240	p25.freedmr-brasil.qsl.br 41000
+7240	p25.freedmr-brasil.qsl.br	41000
 
 # 7245 BRASIL Multiprotocolo P25
-7245	pu4ron.dynv6.net 41000
+7245	pu4ron.dynv6.net	41000
 
 # Uruguay Link
 7487	23.234.230.152	41000
@@ -328,7 +292,7 @@
 7573	p25.docksea.com	41000
 
 # 7941 WHITE MOUNTAIN REPEATER ASSOCIATION
-7941  wmra-multimode.link  41000
+7941	wmra-multimode.link	41000
 
 # 8200 Mountain Lakes Regional Amateur Radio Society
 8200	n2yqt.tourge.net	41000
@@ -346,25 +310,25 @@
 9050	45.77.198.235	41000
 
 # 9480 ICQPODCAST 
-9480	46.101.36.246 41000
+9480	46.101.36.246	41000
 
 # 9517 M17 Project - M17-M17 C Reflector bridge
-9517	112.213.34.65 41002
+9517	112.213.34.65	41002
 
 # 9846 P25 Portal to WW8GM YSF network www.gmarc.org 
 9846	p25.dudetronics.com	41001
 
 # 10100 World Wide	http://dvgateway.m1geo.com/
-10100	dvgateway.m1geo.com		41000
+10100	dvgateway.m1geo.com	41000
 
 # 10101 World Wide TAC 1
-10101	reflector.p25.link		41000
+10101	reflector.p25.link	41000
 
 # 10102 World Wide TAC 2
-10102	reflector.p25.link		41001
+10102	reflector.p25.link	41001
 
 # 10103 World Wide TAC 3
-10103	reflector.p25.link		41002
+10103	reflector.p25.link	41002
 
 # 10120 CQ-UK
 10120	81.150.10.62	41000
@@ -373,16 +337,16 @@
 10169	p25.dipspit.net	41000
 
 # 10200 North America
-10200	p25.dvswitch.org		41000
+10200	p25.dvswitch.org	41000
 
 # 10201 North America TAC 1
-10201	p25.dvswitch.org		41010
+10201	p25.dvswitch.org	41010
 
 # 10202 North America TAC 2
-10202	reflector.p25.link		41003
+10202	reflector.p25.link	41003
 
 # 10203 North America TAC 3
-10203	reflector.p25.link		41004
+10203	reflector.p25.link	41004
 
 # 10207 Arizona 900 P25
 10207	n6ex.ddns.net	41001
@@ -397,43 +361,40 @@
 10216	xlx216.km8v.com	41000
 
 # 10253 N6OCS
-10253 p25.wd6awp.us 41000
+10253 p25.wd6awp.us	41000
 
 # 10255 Southern Ontario
-10255	ve3rd.hopto.org 41000
+10255	ve3rd.hopto.org	41000
 
 # 10260 Poland
-10260	185.174.14.75		41000
+10260	185.174.14.75	41000
 
 # 10294 SkyHub https://skyhublink.com/connections
-10294	kg0sky.duckdns.org  41000
+10294	kg0sky.duckdns.org	41000
 
 # 10300 Europe	https://p25-eu.n18.de/
-10300	176.9.1.168		41000
+10300	176.9.1.168	41000
 
 # 10301	Europe TAC 1
 10301	ea5gvk.duckdns.org	41000
 
 # 10310 Germany HAMNET (Identical to 10320)	http://44.148.230.100/
-10310	44.148.230.100		41000
+10310	44.148.230.100	41000
 
 # 10311 Germany HAMNET Multimode (Identical to 10321)	http://44.148.230.100/
-10311	44.148.230.100		41010
+10311	44.148.230.100	41010
 
 # 10320 Germany INTERNET (Identical to 10310)	http://dv.afu.rwth-aachen.de/
-10320	137.226.79.122		41000
+10320	137.226.79.122	41000
 
 # 10321 Germany INTERNET Multimode (Identical to 10311)	http://dv.afu.rwth-aachen.de/
-10321	137.226.79.122		41010
+10321	137.226.79.122	41010
 
 # 10328 German Pegasus Project http://p25.projekt-pegasus.net/
-10328	5.9.59.26		41000
-
-# 10342 UK
-10342	P25R.northwestdigital.club	41000
+10328	5.9.59.26	41000
 
 # 10350 GB WARC
-10350	warc.ddns.net		41000
+10350	warc.ddns.net	41000
 
 # 10400 Pacific	http://pacificp25.repeaters.info/
 10400	pacificp25.repeaters.info	41000
@@ -442,19 +403,16 @@
 10401	pacifictac1.repeaters.info	41010
 
 # 10402	Pacific	TAC 2
-10402	47.104.177.248		41000
+10402	47.104.177.248	41000
 
 # 10403	Pacific	TAC 3 http://ysf.sz790.com:8082/
-10403	ysf46073.sz790.com		41000
+10403	ysf46073.sz790.com	41000
 
 # 10404	Pacific	TAC 4
 10404	p25tw338.ddns.net	41000
 
 # 10405 Shenzhen City, China http://125.91.17.122:8090/ysf/
 10405	125.91.17.122	42020
-
-# 10406 Zhejiang province, bridged to DMR TG 46055
-10406	p25.zj.digital	41000
 
 # 10407 Shanghai City, China,bridged to DMR TG 46021
 10407	p25021.dyndns.org	41000
@@ -466,7 +424,7 @@
 10410	reflector.tmmarc.org	41000
 
 # 10411 Taiwan, P25 Reflector Bridged to DMR TG 46621 (Hosted by VR2YEP)
-10411 stayalone.idv.hk 41000
+10411	stayalone.idv.hk 	41000
 
 # 10421 DL-Nordwest (dl-nordwest.com) by 9V1LH/DG1BGS and DK5BS
 10421	dl-nordwest.com	41000
@@ -480,14 +438,8 @@
 # 10512 Shanghai, China, SHLK Reflector
 10512	bolelk.vicp.net	41000
 
-# 10666 F5KFF P25 Net in Paris
-10666   f5kff.hd.free.fr  41000
-
 # 10700 Australia NSW Bridge to AU NSW YSF
 10700	p25nsw.gustotech.net	41000
-
-# 10750 Australian Secondary P25 Reflector
-10750	clasn-p25.cloudasn.com	41000
 
 # 10888 Texas
 10888	29520.asnode.org	41000
@@ -502,13 +454,10 @@
 11069	area52.zapto.org	41000
 
 # 11710 Emergency Radio Long Island
-11710  sbanetweb.com  41000
-
-# 17603 URFM17 Universal Reflector
-17603	urf.m17.link	41000
+11710	sbanetweb.com	41000
 
 # 18436 LMR TALK MM DV
-18436 reflector.jchang.io 41000
+18436	reflector.jchang.io	41000
 
 # 20281 GR-KERKYRA-DV
 20281	greece.freedmr.online	41000
@@ -531,12 +480,6 @@
 # 22212 IT PIEDMONT GDO
 22212	p25gdo.duckdns.org	41000
 
-# 22221 HBLINK IT-DMR REGIONALE LOMBARDIA
-22221	dagobah.hblink.it	41000
-
-# 22222 North Carolina NCC-1701
-22222	NCC-1701-P25.ddns.net	41001
-
 # 22252 IT MULTIPROTOCOL NETWORK
 22252	46.226.178.80	41000
 
@@ -544,13 +487,13 @@
 22258	94.177.173.53	41000
 
 # 22273 IT-C4FM_BAT
-22273 82.85.236.36  41000
+22273	82.85.236.36	41000
 
 # 22556 URF556 Stafford Virginia
-22556 urf556.kq4tnv.net	41000
+22556	urf556.kq4tnv.net	41000
 
 # 22625 P25 Romania
-22625 82.165.47.94 41000
+22625	82.165.47.94	41000
 
 # 23225 Austria
 23225	service.oe9hamnet.at	41000
@@ -562,22 +505,13 @@
 23456	kc1noc.duckdns.org	41000
 
 # 23501 Euro Football
-23501 p25-23501.ka1vsc.com 41000
+23501	p25-23501.ka1vsc.com	41000
 
 # 23511 LEFARS Multi-Reflector
 23511	xlxlef.gb7hh.co.uk	41000
 
-# 23522 GB-PrestonARS-P25
-23522	23522p25ref.dyndns.org	41000
-
-# 23551 P25 Scotland
-23551	p25scotland.ddns.net	41000
-
 # 23556 DVSPH Multimode
 23556	xlx600.dvsph.net	41000
-
-# 23595 OZ-DMR
-23595	p25.oz-dmr.network	41000
 
 # 24033 2 Meter Crew Anti-Net
 24033	wg5eek.com	41000
@@ -585,32 +519,29 @@
 # 25508 South Eastern MA P25
 25508	k1rfi.net	41000
 
-# 25605 Russia Ekaterinburg 
-25605   ysf.386i.ru     41000
-
 # 25617 Russia Kavkaz
 25617	kavkaz.qrz.ru	41000
 
 # 25641 Russia P25 Net
-25641	194.182.85.217		41000
+25641	194.182.85.217	41000
 
 # 26078 Poland HBLink Network
 26078	p25.hblink.kutno.pl	41000
 
 # 26230 German RegHannover
-26230	p25-tg26230.dl9cma.net 41010
+26230	p25-tg26230.dl9cma.net	41010
 
 # 26231 German NI-Mitte
-26231	p25-tg26231.dl9cma.net 41000
+26231	p25-tg26231.dl9cma.net	41000
 
 # 26269 Multimode HE_RLP
-26269 urf169.dc9vq.de 41000
+26269	urf169.dc9vq.de	41000
 
 # 26285 German Oberbayern Region
 26285	xlx850.bm262.de	41008
 
 # 26334 German Funknetz-Celle
-26334 85.215.198.111 41000
+26334	85.215.198.111	41000
 
 # 26444 German Inselfreunde Net
 26444	xlx850.bm262.de	41004
@@ -634,10 +565,7 @@
 27568	139.144.61.167	41003
 
 # 28299 America-Ragchew
-28299	arcp25.duckdns.org		41001
-
-# 29252 Oklahoma Hamsomniacs
-29252	hamsomniac.mooo.com	41000
+28299	arcp25.duckdns.org	41001
 
 # 30639 NorCal-Bridge / Multimode-P25-TG30639
 30639	nfonorcalp25.dyndns.org	41000
@@ -649,13 +577,13 @@
 31044	p25.wny-digital.network	41000
 
 # 31057 AF5XP Sulphur,Louisiana
-31057	af5xp.ddns.net		41000
+31057	af5xp.ddns.net	41000
 
 # 31059 Vidalia Net P25
 31059	vidalianet.cbridge.net	41000
 
 # 31062 Mountain West
-31062	p25.mw-dmr.net		41000
+31062	p25.mw-dmr.net	41000
 
 # 31069 K6JWN Multimode-P25
 31069	p25.k6jwn.org	41000
@@ -667,16 +595,10 @@
 31078	216.240.173.55	41000
 
 # 31079 ALERT Radio / Multimode P25/DMR
-31079	927.org			41001
+31079	927.org		41001
 
 # 31138 kingsland Ga
 31138	kingsland.cbridge.net	41000
-
-# 31177 WESDIG P25 Reflector
-31177	p25.wesdig.com	41000
-
-# 31121 First Coast FL
-31121	dvse.dmrnet.net	41000
 
 # 31123 Florida Treasure Coast
 31123	p25.kg4orq.com	41000
@@ -688,13 +610,13 @@
 31171	illink.radiotechnology.xyz	41000
 
 # 31181 Indiana Link
-31181  174.137.23.148  41000
+31181	174.137.23.148	41000
 
 # 31188 Southern Indiana
 31188	w9windigital.org	41000
 
 # 31207 Sunflower Net
-31207   155.138.244.192   41000
+31207	155.138.244.192	41000
 
 # 31217 Central Illinois Skywarn - Linked to Brandmeister TG 311899
 31217	tg31217.kd9koo.com	41000
@@ -727,19 +649,19 @@
 31337	bridge.kc5jmj.com	41000
 
 # 31377 Foothills Wave Whisperers
-31377 66.226.62.35 41000
+31377	66.226.62.35	41000
 
 # 31379 Piedmont Triad Network
-31379 130.51.21.144 41000
+31379	130.51.21.144	41000
 
 # 31390 TORCON WX
-31390 167.88.45.175 41000
+31390	167.88.45.175	41000
 
 # 31391 TORCON ARC- TORCON Amateur Radio Club
-31391 167.88.45.175 41001
+31391	167.88.45.175	41001
 
 # 31392 TORCON TAC
-31392 167.88.45.175 41002
+31392	167.88.45.175	41002
 
 # 31395 Cleveland Skywarn Backbone
 31395	backbone.ad8g.net	41000
@@ -751,18 +673,15 @@
 31340	p25-31340.k2dls.net	41000
 
 # 31341 South Jersey, http://p25.kc2idb.net
-31341	p25.kc2idb.net		41000
+31341	p25.kc2idb.net	41000
 
 # 31403 Oklahoma Link
-31403	3.208.70.29		41000
+31403	3.208.70.29	41000
 
 # XLX045A P25 <-> DMR/DSTAR/YSF/NXDN <-> BM TG31425 PA Wide Cross Mode
 31425	70.44.20.24	41001
 
-# 31424 SVARC-Shenango Valley Amateur Radio Club- K3WRB
-31424	p25.n1tvi.net	41000
-
-#  PA Cross Mode (alt), 31426
+#	PA Cross Mode (alt), 31426
 31426	3.215.215.169	41001
 
 # 31444	RI DIGITAL LINK TG#31444
@@ -796,13 +715,13 @@
 31620	wb5ekup25.duckdns.org	41000
 
 # 31644 BM Link P25 to DMR
-31644 homeservice.freeddns.org 41000
+31644	homeservice.freeddns.org	41000
 
 # 31655 Ham Radio Venture Overland
 31655	149.248.8.155	41000
 
 # 31665 TGIF Network, http://tgif.network
-31665	tgif.network		41000
+31665	tgif.network	41000
 
 # 31672 P25 Pi-Star chat
 31672	p25-31672.pistar.uk	41000
@@ -814,13 +733,13 @@
 31691	net.w3axl.com	43169
 
 # 31777 DX-LINK
-31777	8.9.4.102		41000
+31777	8.9.4.102	41000
 
 # 31888 KG4JPL North-Central Florida
-31888	p25.kg4jpl.com		41000
+31888	p25.kg4jpl.com	41000
 
 # 31910 LMRNET LMR Talkaround
-31910 172.233.211.93    41000
+31910 172.233.211.93	41000
 
 # 31947 K0MGS Western Missouri/KC Metro
 31947	p25.ddns.me	41000
@@ -831,17 +750,11 @@
 # 32103 CW-Ops Academy
 32103	cwops.dyndns.org	41000
 
-# 33015 KP4CA Digital Network
-33015	kp4ca-p25.ddns.net	41000
-
 # 33420 Durango Mexico Digital Network
 33420	p25-mx.ddns.net	41000
 
 # 33581 NET TALK
 33581	omiss.dyndns.org	41000
-
-# 37030 RED SKYNET
-37030	skynet.xreflector.es	41000
 
 # 37225 Haiti Digital Communications League (HDCL) P25
 37225	3.215.215.169	41011
@@ -901,10 +814,10 @@
 50210	edone.no-ip.com	41000
 
 # 50516 Western NSW TAC 1
-50516 54.66.203.116 41000
+50516	54.66.203.116	41000
 
 # 50517 Western NSW TAC 2
-50517 54.66.203.116 41010
+50517	54.66.203.116	41010
 
 # 50525 Bridge to YSF, NXDN and DMR
 50525	50525.p25dvm.com	41000
@@ -914,9 +827,6 @@
 
 # 50536 FreeSTAR VK
 50536	p25tg50536.vkradio.com	41001
-
-# 51502 DX1ACE
-51502	p25-dx1ace.hopto.org	41000
 
 # 51503 US Philippines P25 network
 51503	45.79.76.10	41000
@@ -946,7 +856,7 @@
 52910	p25x.mywire.org	41000
 
 # 53099 New Zealand bridge to D-Star, DMR and NXDN
-53099	203.86.206.49		41000
+53099	203.86.206.49	41000
 
 # 54100 Thailand
 54100	hs1qcj.ddns.net	41000
@@ -955,10 +865,10 @@
 55100	192.155.88.30	41000
 
 # 55295 (KT0ADS) TOADS Digital Voice
-55295 47.36.253.75 41000
+55295	47.36.253.75	41000
 
 # 57686 KOTA KIDSONTHEAIR
-57686 172.234.216.120 41000
+57686	172.234.216.120	41000
 
 # 60100 K8SDR SignalsEverywhere Experimenters Club
 60100	p25.signalseverywhere.com	41000
@@ -991,14 +901,11 @@
 65105	UHDARCtac2.mywire.org	41004
 
 # 65123 Murphy Radio Network (MRN)
-65123   45.33.22.225   41000
+65123	45.33.22.225	41000
 
 # 65400 XLX288 Reflector
 65400	xlx288.unusualperson.com	41000
 
-# 93415 ECHQ P25 Club
-93415 emfcamp.james.ac 5555
-
 # 460851 TG460851 Guiyang China
-460851	120.76.96.210 41000
+460851	120.76.96.210	41000
 

--- a/P25Gateway/P25Hosts.txt
+++ b/P25Gateway/P25Hosts.txt
@@ -49,13 +49,13 @@
 260	80.211.195.50	41005
 
 # 276 Amateur Radio Network
-276 p25.kc8cpw.com	41000
+276	p25.kc8cpw.com	41000
 
 # 304 W8ARA P25
 304	ara.selfip.net	41000
 
 # 312 TriState (IL, IN, WI) P25
-312 p25.tristatedmr.org	41000
+312	p25.tristatedmr.org	41000
 
 # 334 Mexico P25 (by XE1F)
 334	reflector.p25.link	41008
@@ -76,7 +76,7 @@
 456	456.ham-p25.de	41000
 
 # 478 Ham Radio Village URF478
-478 urf.hamvillage.org 41000
+478	urf.hamvillage.org	41000
 
 # 554 Georgia 900 P25 555 backup
 554	georgia900p25.us	41003
@@ -157,7 +157,7 @@
 946	xlx.flagandtorchsociety.com	41000
 
 # 947 W8LRK Livingston Amateur Radio Klub (Bridged to XLX947B)
-947 w8lrkp25.dyndns.org	41001
+947	w8lrkp25.dyndns.org	41001
 
 # 1007 The Harley-Hangout "TGIF TG-1007 Multi-Function Bridge"
 1007	43773.kb5rir.com	41003
@@ -361,7 +361,7 @@
 10216	xlx216.km8v.com	41000
 
 # 10253 N6OCS
-10253 p25.wd6awp.us	41000
+10253	p25.wd6awp.us	41000
 
 # 10255 Southern Ontario
 10255	ve3rd.hopto.org	41000
@@ -424,7 +424,7 @@
 10410	reflector.tmmarc.org	41000
 
 # 10411 Taiwan, P25 Reflector Bridged to DMR TG 46621 (Hosted by VR2YEP)
-10411	stayalone.idv.hk 	41000
+10411	stayalone.idv.hk	41000
 
 # 10421 DL-Nordwest (dl-nordwest.com) by 9V1LH/DG1BGS and DK5BS
 10421	dl-nordwest.com	41000
@@ -595,7 +595,7 @@
 31078	216.240.173.55	41000
 
 # 31079 ALERT Radio / Multimode P25/DMR
-31079	927.org		41001
+31079	927.org	41001
 
 # 31138 kingsland Ga
 31138	kingsland.cbridge.net	41000
@@ -739,7 +739,7 @@
 31888	p25.kg4jpl.com	41000
 
 # 31910 LMRNET LMR Talkaround
-31910 172.233.211.93	41000
+31910	172.233.211.93	41000
 
 # 31947 K0MGS Western Missouri/KC Metro
 31947	p25.ddns.me	41000


### PR DESCRIPTION
Cleaned up P25Hosts.txt

- Fixed formatting inconsistencies
- Removed talk groups where DNS records of reflectors were not resolvable
  - zldigitalreflectors.hopto.org
  - p25.xlx822.com
  - nz6d.dx40.com
  - urf.kf3rry.org
  - misc.openreflector.com
  - hamsomniac.mooo.com
  - p25.dstar-yo.ro
  - p25.r1ik.ru
  - ontxlink.hopto.org
  - p25tn.w4kdg.org
  - p25.dmr-peru.pe
  - P25R.northwestdigital.club
  - p25.zj.digital
  - f5kff.hd.free.fr
  - clasn-p25.cloudasn.com
  - urf.m17.link
  - dagobah.hblink.it
  - NCC-1701-P25.ddns.net
  - 23522p25ref.dyndns.org
  - p25scotland.ddns.net
  - p25.oz-dmr.network
  - ysf.386i.ru
  - p25.wesdig.com
  - dvse.dmrnet.net
  - p25.n1tvi.net
  - kp4ca-p25.ddns.net
  - skynet.xreflector.es
  - p25-dx1ace.hopto.org
  - emfcamp.james.ac